### PR TITLE
Refactor CLI parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +239,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,10 +355,11 @@ dependencies = [
 
 [[package]]
 name = "dalfs"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "env_logger",
  "fuser",
  "futures",
@@ -272,6 +367,7 @@ dependencies = [
  "log",
  "opendal",
  "sequence_trie",
+ "tap",
  "time 0.1.45",
  "tokio",
 ]
@@ -546,6 +642,12 @@ name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1576,6 +1678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1720,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -1842,6 +1956,12 @@ dependencies = [
  "libc",
  "log",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ time = "0.1"
 sequence_trie = "0.0.13"
 chrono = "0.4.30"
 log = "0.4.20"
+clap = { version = "4.4.6", features = ["derive"] }
+tap = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cargo build
 To run, you will need to provide a series of 
 
 ```bash
-cargo run --relase -- <mount-point> [device] -t <scheme> ...
+cargo run --relase -- <mount-point> -t <scheme> ...
 ```
 
 where the `mount-point` is a path to mount the filesystem; `scheme` is an OpenDAL scheme, all in lowercase (e.g. "ftp", "s3", "fs", etc.).
@@ -85,7 +85,7 @@ The remaining parameters are `<key>=<value>[,<key>=<value>]` pairs needed by Ope
 Currently `fs` and `s3` backends are tested. For example, the following command will mount a filesystem using the data in your `/tmp` directory to the mount-point.
 
 ```bash
-cargo run --relase -- <mount-point> -t fs -o root=/tmp # or: cargo run --relase -- <mount-point> /tmp -t fs
+cargo run --relase -- <mount-point> -t fs -o root=/tmp
 ```
 
 <img width="1185" alt="image" src="https://github.com/Inokinoki/DalFs/assets/8311300/c591ffe1-be35-4c79-8ffa-368c66872b9f">
@@ -93,7 +93,7 @@ cargo run --relase -- <mount-point> -t fs -o root=/tmp # or: cargo run --relase 
 And the following mount a filesystem backed by s3:
 
 ```bash
-cargo run <mount-point> s3 root=/tmp endpoint=<end-point-url> bucket=<bucket> access_key_id=<access-key-id> secret_access_key=<secret-access-key> region=auto
+cargo run <mount-point> -t s3 -o root=/tmp,endpoint=<end-point-url>,bucket=<bucket>,access_key_id=<access-key-id>,secret_access_key=<secret-access-key>,region=auto
 ```
 
 For more details and more backends, please check [OpenDAL scheme doc](https://opendal.apache.org/docs/rust/opendal/enum.Scheme.html).

--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ cargo build
 To run, you will need to provide a series of 
 
 ```bash
-cargo run <mount-point> <scheme> ...
+cargo run --relase -- <mount-point> [device] -t <scheme> ...
 ```
 
 where the `mount-point` is a path to mount the filesystem; `scheme` is an OpenDAL scheme, all in lowercase (e.g. "ftp", "s3", "fs", etc.).
 
-The remaining parameters are `<key>=<value>` pairs needed by OpenDAL schemes.
+The remaining parameters are `<key>=<value>[,<key>=<value>]` pairs needed by OpenDAL schemes.
 
 Currently `fs` and `s3` backends are tested. For example, the following command will mount a filesystem using the data in your `/tmp` directory to the mount-point.
 
 ```bash
-cargo run <mount-point> fs root=/tmp
+cargo run --relase -- <mount-point> -t fs -o root=/tmp # or: cargo run --relase -- <mount-point> /tmp -t fs
 ```
 
 <img width="1185" alt="image" src="https://github.com/Inokinoki/DalFs/assets/8311300/c591ffe1-be35-4c79-8ffa-368c66872b9f">

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,73 +1,43 @@
-use opendal::Operator;
-use opendal::Result;
+use clap::{Args, Parser, Subcommand};
 use opendal::Scheme;
+use std::{collections::HashMap, str::FromStr};
 
-use std::collections::HashMap;
-use std::env;
-
-use log;
-
-#[feature(str_split_remainder)]
-pub fn get_operator_from_env(scheme: &str) -> Result<Operator> {
-    let mut map = HashMap::new();
-
-    let mut args = env::args_os();
-    args.next(); args.next(); args.next();  // Ignore the first three args
-    for arg_os in args {
-        log::debug!("Parsing arg: {:?}", arg_os);
-        let arg = arg_os.to_str().unwrap();
-        let mut split = arg.split('=');
-        map.insert(split.next().unwrap().to_string(), split.next().unwrap_or(&"").to_string());
-    }
-    log::debug!("Parsed {:?}", map);
-
-    get_operator_with_config(scheme, map)
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct App {
+    #[command(subcommand)]
+    pub command: Commands,
 }
 
-pub fn get_operator_with_config(scheme: &str, map: HashMap<String, String>) -> Result<Operator> {
-    match scheme {
-        "atomicserver" => Operator::via_map(Scheme::Atomicserver, map),
-        "azblob" => Operator::via_map(Scheme::Azblob, map),
-        "azdls" => Operator::via_map(Scheme::Azdls, map),
-        "cacache" => Operator::via_map(Scheme::Cacache, map),
-        "cos" => Operator::via_map(Scheme::Cos, map),
-        "dashmap" => Operator::via_map(Scheme::Dashmap, map),
-        "etcd" => Operator::via_map(Scheme::Etcd, map),
-        "foundationdb" => Operator::via_map(Scheme::Foundationdb, map),
-        "fs" => Operator::via_map(Scheme::Fs, map),
-        "ftp" => Operator::via_map(Scheme::Ftp, map),
-        "gcs" => Operator::via_map(Scheme::Gcs, map),
-        "ghac" => Operator::via_map(Scheme::Ghac, map),
-        "hdfs" => Operator::via_map(Scheme::Hdfs, map),
-        "http" => Operator::via_map(Scheme::Http, map),
-        "ipfs" => Operator::via_map(Scheme::Ipfs, map),
-        "ipmfs" => Operator::via_map(Scheme::Ipmfs, map),
-        "memcached" => Operator::via_map(Scheme::Memcached, map),
-        "memory" => Operator::via_map(Scheme::Memory, map),
-        "minimoka" => Operator::via_map(Scheme::MiniMoka, map),
-        "moka" => Operator::via_map(Scheme::Moka, map),
-        "obs" => Operator::via_map(Scheme::Obs, map),
-        "onedrive" => Operator::via_map(Scheme::Onedrive, map),
-        "gdrive" => Operator::via_map(Scheme::Gdrive, map),
-        "dropbox" => Operator::via_map(Scheme::Dropbox, map),
-        "oss" => Operator::via_map(Scheme::Oss, map),
-        "persy" => Operator::via_map(Scheme::Persy, map),
-        "redis" => Operator::via_map(Scheme::Redis, map),
-        "postgresql" => Operator::via_map(Scheme::Postgresql, map),
-        "rocksdb" => Operator::via_map(Scheme::Rocksdb, map),
-        "s3" => Operator::via_map(Scheme::S3, map),
-        "sftp" => Operator::via_map(Scheme::Sftp, map),
-        "sled" => Operator::via_map(Scheme::Sled, map),
-        "supabase" => Operator::via_map(Scheme::Supabase, map),
-        "vercelartifacts" => Operator::via_map(Scheme::VercelArtifacts, map),
-        "wasabi" => Operator::via_map(Scheme::Wasabi, map),
-        "webdav" => Operator::via_map(Scheme::Webdav, map),
-        "webhdfs" => Operator::via_map(Scheme::Webhdfs, map),
-        "redb" => Operator::via_map(Scheme::Redb, map),
-        "tikv" => Operator::via_map(Scheme::Tikv, map),
-        _ => {
-            panic!("Not yet support {}", scheme);
-        }
-    }
-} 
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    Mount(MountArgs),
+}
 
+#[derive(Debug, Args)]
+pub struct MountArgs {
+    pub mount_point: String,
+    pub device: Option<String>,
+
+    /// OpenDAL scheme
+    #[arg(short, long, value_parser = parse_type)]
+    pub r#type: Scheme,
+
+    /// Configuration of the OpenDAL scheme in the format <key1>=<val1>,<key2>=<val2>,..
+    #[arg(short, long, value_parser = parse_options)]
+    pub options: Option<HashMap<String, String>>,
+}
+
+fn parse_options(raw: &str) -> Result<HashMap<String, String>, String> {
+    raw.split(',')
+        .map(|kv| {
+            kv.split_once('=')
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .ok_or(String::from("Invalid key value format".to_string()))
+        })
+        .collect::<Result<HashMap<String, String>, String>>()
+}
+
+fn parse_type(raw: &str) -> Result<Scheme, String> {
+    Scheme::from_str(raw).map_err(|_| "Invalid OpenDAL scheme".to_string())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,10 @@
-use clap::{Args, Parser, Subcommand};
+use clap::Parser;
 use opendal::Scheme;
 use std::{collections::HashMap, str::FromStr};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct App {
-    #[command(subcommand)]
-    pub command: Commands,
-}
-
-#[derive(Debug, Subcommand)]
-pub enum Commands {
-    Mount(MountArgs),
-}
-
-#[derive(Debug, Args)]
-pub struct MountArgs {
     pub mount_point: String,
     pub device: Option<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, str::FromStr};
 #[command(author, version, about, long_about = None)]
 pub struct App {
     pub mount_point: String,
-    pub device: Option<String>,
 
     /// OpenDAL scheme
     #[arg(short, long, value_parser = parse_type)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,22 +25,17 @@ async fn main() -> ExitCode {
 }
 
 fn run(config: App) -> Result<(), Box<dyn std::error::Error>> {
-    match config.command {
-        config::Commands::Mount(args) => {
-            let mut options = args.options.unwrap_or_default();
-            if let Some(root) = args.device {
-                options.insert("root".to_string(), root);
-            }
-
-            let fs = dalfs::DalFs {
-                op: Operator::via_map(args.r#type, options)?
-                    .tap(|op| log::debug!("operator: {op:?}")),
-                inodes: inode::InodeStore::new(0o550, 1000, 1000), // Temporarilly hardcode
-            };
-
-            fuser::mount(fs, args.mount_point, &[])?;
-        }
+    let mut options = config.options.unwrap_or_default();
+    if let Some(root) = config.device {
+        options.insert("root".to_string(), root);
     }
+
+    let fs = dalfs::DalFs {
+        op: Operator::via_map(config.r#type, options)?.tap(|op| log::debug!("operator: {op:?}")),
+        inodes: inode::InodeStore::new(0o550, 1000, 1000), // Temporarilly hardcode
+    };
+
+    fuser::mount(fs, config.mount_point, &[])?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> ExitCode {
     env_logger::init();
 
     if let Err(e) = run(config) {
-        log::error!("{}", e);
+        log::error!("{e}");
         return ExitCode::FAILURE;
     }
 
@@ -25,13 +25,9 @@ async fn main() -> ExitCode {
 }
 
 fn run(config: App) -> Result<(), Box<dyn std::error::Error>> {
-    let mut options = config.options.unwrap_or_default();
-    if let Some(root) = config.device {
-        options.insert("root".to_string(), root);
-    }
-
     let fs = dalfs::DalFs {
-        op: Operator::via_map(config.r#type, options)?.tap(|op| log::debug!("operator: {op:?}")),
+        op: Operator::via_map(config.r#type, config.options.unwrap_or_default())?
+            .tap(|op| log::debug!("operator: {op:?}")),
         inodes: inode::InodeStore::new(0o550, 1000, 1000), // Temporarilly hardcode
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ async fn main() -> ExitCode {
 
     if let Err(e) = run(config) {
         log::error!("{}", e);
+        return ExitCode::FAILURE;
     }
 
     ExitCode::SUCCESS


### PR DESCRIPTION
Refactor CLI usage to be similar to `mount`.

Example in the README can be written as:

```txt
cargo run --release -- mount <mount-point> /tmp -t fs
```

or:

```txt
cargo run --release -- mount <mount-point> -t fs -o root=/tmp
```